### PR TITLE
only append deprecate onto function properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build_tests
+.idea

--- a/dist.js
+++ b/dist.js
@@ -46,7 +46,7 @@ function deprecate(propType, message) {
 function addIsDeprecated(PropTypes) {
   var newPropTypes = _extends({}, PropTypes);
   for (var type in newPropTypes) {
-    if (newPropTypes.hasOwnProperty(type) && typeof newPropTypes[type] === "function") {
+    if (newPropTypes.hasOwnProperty(type) && newPropTypes[type].constructor === Function) {
       var propType = newPropTypes[type];
       propType = propType.bind(newPropTypes);
       propType.isDeprecated = deprecate.bind(newPropTypes, propType);

--- a/dist.js
+++ b/dist.js
@@ -25,8 +25,8 @@ function deprecate(propType, message) {
       args[_key] = arguments[_key];
     }
 
-    var props = args[0];
-    var propName = args[1];
+    var props = args[0],
+        propName = args[1];
 
     var prop = props[propName];
     if (prop !== undefined && prop !== null && !warned) {
@@ -46,7 +46,7 @@ function deprecate(propType, message) {
 function addIsDeprecated(PropTypes) {
   var newPropTypes = _extends({}, PropTypes);
   for (var type in newPropTypes) {
-    if (newPropTypes.hasOwnProperty(type)) {
+    if (newPropTypes.hasOwnProperty(type) && typeof newPropTypes[type] === "function") {
       var propType = newPropTypes[type];
       propType = propType.bind(newPropTypes);
       propType.isDeprecated = deprecate.bind(newPropTypes, propType);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ export function deprecate(propType, message) {
 export function addIsDeprecated(PropTypes) {
   let newPropTypes = {...PropTypes};
   for (const type in newPropTypes) {
-    if (newPropTypes.hasOwnProperty(type)) {
+    if (newPropTypes.hasOwnProperty(type) && typeof newPropTypes[type] === "function") {
       let propType = newPropTypes[type];
       propType = propType.bind(newPropTypes);
       propType.isDeprecated = deprecate.bind(newPropTypes, propType);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ export function deprecate(propType, message) {
 export function addIsDeprecated(PropTypes) {
   let newPropTypes = {...PropTypes};
   for (const type in newPropTypes) {
-    if (newPropTypes.hasOwnProperty(type) && typeof newPropTypes[type] === "function") {
+    if (newPropTypes.hasOwnProperty(type) && newPropTypes[type].constructor === Function) {
       let propType = newPropTypes[type];
       propType = propType.bind(newPropTypes);
       propType.isDeprecated = deprecate.bind(newPropTypes, propType);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",
+    "prop-types": "^15.5.10",
     "react": "^0.14.7"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -1,28 +1,45 @@
 'use strict'
 var expect = require('chai').expect;
 var React = require('react');
-var PropTypes = require('react').PropTypes;
+var LegacyPropTypes = require('react').PropTypes;
 var addIsDeprecated = require('./dist').addIsDeprecated;
 var deprecate = require('./dist').deprecate;
+var PropTypes = require('prop-types');
 
 
 describe('react-is-deprecated', () => {
-  Object.freeze(PropTypes)
-  it('should not mutate the React PropTypes API', () => {
-    let initialObjectType = PropTypes.object
-    const NewPropTypes = addIsDeprecated(PropTypes)
-    expect(PropTypes.object.isDeprecated).to.equal(undefined)
-    expect(PropTypes.object === initialObjectType).to.equal(true)
-  })
-  console.log('PropTypes before tests', PropTypes.object.isDeprecated);
-  it('should export an `addIsDeprecated` function', () => {
-    expect(addIsDeprecated).to.be.a('function')
-  })
-  it('should export an `deprecate` function', () => {
-    expect(deprecate).to.be.a('function')
-  })
-  it('should add an isDeprecated method to the passed PropTypes.', () => {
-    const NewPropTypes = addIsDeprecated(PropTypes)
-    expect(NewPropTypes.object.isDeprecated).to.be.a('function')
-  })
+    it('should export an `addIsDeprecated` function', () => {
+        expect(addIsDeprecated).to.be.a('function')
+    })
+    it('should export an `deprecate` function', () => {
+        expect(deprecate).to.be.a('function')
+    })
+    describe('with legacy React.Proptypes object', () => {
+        Object.freeze(LegacyPropTypes)
+        it('should not mutate the React PropTypes API', () => {
+            let initialObjectType = LegacyPropTypes.object
+            const NewPropTypes = addIsDeprecated(LegacyPropTypes)
+            expect(LegacyPropTypes.object.isDeprecated).to.equal(undefined)
+            expect(LegacyPropTypes.object === initialObjectType).to.equal(true)
+        })
+        console.log('PropTypes before tests', LegacyPropTypes.object.isDeprecated);
+        it('should add an isDeprecated method to the passed PropTypes.', () => {
+            const NewPropTypes = addIsDeprecated(LegacyPropTypes)
+            expect(NewPropTypes.object.isDeprecated).to.be.a('function')
+        })
+    })
+    describe('with external prop-types library', () => {
+        Object.freeze(PropTypes)
+        it('should not mutate the React PropTypes API', () => {
+            let initialObjectType = PropTypes.object
+            const NewPropTypes = addIsDeprecated(PropTypes)
+            expect(PropTypes.object.isDeprecated).to.equal(undefined)
+            expect(PropTypes.object === initialObjectType).to.equal(true)
+        })
+        console.log('PropTypes before tests', PropTypes.object.isDeprecated);
+        it('should add an isDeprecated method to the passed PropTypes.', () => {
+            const NewPropTypes = addIsDeprecated(PropTypes)
+            expect(NewPropTypes.object.isDeprecated).to.be.a('function')
+        })
+    })
 })


### PR DESCRIPTION
Added a check so it only puts the deprecate function onto properties that are functions, as anything other than a function will cause it to break.

This resolves #6 